### PR TITLE
Fix KeyError when adjusting Flap Direction Update select.py Fix

### DIFF
--- a/custom_components/daikin_d3net/select.py
+++ b/custom_components/daikin_d3net/select.py
@@ -139,6 +139,6 @@ class D3netSelectFanDirection(D3netSelectBase):
     async def async_select_option(self, option: str) -> None:
         """Change the Fan Direction."""
         await self._unit.async_write_prepare()
-        self._unit.status.fan_direct = D3netFanDirection[option.lower()]
+        self._unit.status.fan_direct = D3netFanDirection[option.upper()]
         await self._unit.async_write_commit()
         self.async_write_ha_state()


### PR DESCRIPTION
Resolves KeyError when trying to set flap positions. 

Fixed by replacing D3netFanDirection[option.lower()] to D3netFanDirection[option.upper()] matching the D3netFanDirection defined variables.